### PR TITLE
Add correct testing dependency to dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,7 +26,9 @@ bugtracker.github = user:drzigman
 
 [AutoPrereqs]
 skip = ^strict$|^warnings$|^utf8$
-Test::Moose::More = 0.035
+
+[Prereqs / TestRequires]
+Test::Moose::More = 0.029
 
 [Clean]
 


### PR DESCRIPTION
Test::Moose::More requires version 0.029 minimum for testing roles.
