### PR TITLE
Added resend_verification_email to the Domain role

### DIFF
--- a/lib/WWW/LogicBoxes.pm
+++ b/lib/WWW/LogicBoxes.pm
@@ -229,6 +229,8 @@ Retrieval of and management of registered domains.
 
 =item L<renew_domain|WWW::LogicBoxes::Role::Command::Domain/renew_domain>
 
+=item L<resend_verficiation_email|WWW::LogicBoxes::Role::Command::Domain/resend_verficiation_email>
+
 =back
 
 =head2 L<Domain Private Nameservers|WWW::LogicBoxes::Role::Command::Domain::PrivateNameServer>

--- a/lib/WWW/LogicBoxes.pm
+++ b/lib/WWW/LogicBoxes.pm
@@ -229,7 +229,7 @@ Retrieval of and management of registered domains.
 
 =item L<renew_domain|WWW::LogicBoxes::Role::Command::Domain/renew_domain>
 
-=item L<resend_verficiation_email|WWW::LogicBoxes::Role::Command::Domain/resend_verficiation_email>
+=item L<resend_verification_email|WWW::LogicBoxes::Role::Command::Domain/resend_verification_email>
 
 =back
 

--- a/lib/WWW/LogicBoxes/Role/Command/Domain.pm
+++ b/lib/WWW/LogicBoxes/Role/Command/Domain.pm
@@ -361,12 +361,18 @@ sub resend_verification_email{
             croak 'Domain already verified';
         }
 
-        $self->submit({
+        $response = $self->submit({
             method => 'domains__raa__resend_verification',
             params => {
                 'order-id' => $args{id}
             }
         });
+        if( $response->{result} eq 'true' ){
+            return 1;
+        }
+        elsif( $response->{result} eq 'false' ){
+            return 0;
+        }
     }
     catch {
         if( $_ =~ m/You are not allowed to perform this action/ ) {

--- a/lib/WWW/LogicBoxes/Role/Command/Domain.pm
+++ b/lib/WWW/LogicBoxes/Role/Command/Domain.pm
@@ -341,6 +341,34 @@ sub renew_domain {
     };
 }
 
+sub resend_verification_email{
+    my $self = shift;
+    my ( %args ) = validated_hash(
+        \@_,
+        id => { isa => Int },
+    );
+
+    return try {
+        my $domain = $self->get_domain_by_id( $args{id} );
+
+        if( !$domain ) {
+            croak 'No such domain exists';
+        }
+        if( $domain->verification_status eq 'Verified' ){
+            croak 'Domain already verified';
+        }
+        $self->submit({
+            method => 'domains__raa__resend_verification',
+            params => {
+                'order-id' => $args{id}
+            }
+        });
+    }
+    catch {
+        croak $_;
+    };
+}
+
 1;
 
 __END__
@@ -579,5 +607,15 @@ See L<WWW::LogicBoxes::DomainRequest/invoice_option> for additional details abou
 =back
 
 Returns an instance of the domain object.
+
+=head2 resend_verification_email
+
+    use WWW::LogicBoxes;
+    use WWW::LogicBooxes::Domain;
+
+    my $logic_boxes = WWW::LogicBoxe->new( ... );
+    $logic_boxes->resend_verification_email( id => $domain->id );
+
+Given an Integer L<domain|WWW::LogicBoxes::Domain> id, resends Verification email. Returns true if executed successfully or false if not
 
 =cut

--- a/lib/WWW/LogicBoxes/Role/Command/Raw.pm
+++ b/lib/WWW/LogicBoxes/Role/Command/Raw.pm
@@ -28,7 +28,7 @@ Readonly our $API_METHODS => {
             qw(available suggest-names v5/suggest-names validate-transfer search customer-default-ns orderid details details-by-name locks tel/cth-details)
         ],
         POST => [
-            qw(register transfer eu/transfer eu/trade uk/transfer renew modify-ns add-cns modify-cns-name modify-cns-ip delete-cns-ip modify-contact modify-privacy-protection modify-auth-code enable-theft-protection disable-theft-protection tel/modify-whois-pref resend-rfa uk/release cancel-transfer delete restore de/recheck-ns dotxxx/assoication-details)
+            qw(register transfer eu/transfer eu/trade uk/transfer renew modify-ns add-cns modify-cns-name modify-cns-ip delete-cns-ip modify-contact modify-privacy-protection modify-auth-code enable-theft-protection disable-theft-protection tel/modify-whois-pref resend-rfa uk/release cancel-transfer delete restore de/recheck-ns dotxxx/assoication-details raa/resend-verification)
         ],
     },
     contacts => {

--- a/t/role/command/domain/10-resend_verification_email.t
+++ b/t/role/command/domain/10-resend_verification_email.t
@@ -12,36 +12,45 @@ use lib "$FindBin::Bin/../../../lib";
 use Test::WWW::LogicBoxes::Domain qw( create_domain );
 use Test::WWW::LogicBoxes qw( create_api );
 
-use WWW::LogicBoxes::Domain;
+use WWW::LogicBoxes;
 
 my $logic_boxes = create_api;
 
 subtest 'Resend Email Verification For Domain That Does Not Exist - Throws Exception' => sub {
     throws_ok {
         $logic_boxes->resend_verification_email( id => 999999999 );
-    } qr/No such domain exists/;
+    }
+    qr/No such domain/;
 };
 
 subtest 'Resend Email Verification For Domain That Does Not Need It - Throws Exception' => sub {
-    my $mocked_domain_status = Test::MockModule->new('WWW::LogicBoxes::Domain');
-    $mocked_domain_status->mock(
-        'verification_status',
+    my $domain        = create_domain();
+    my $mocked_submit = Test::MockModule->new('WWW::LogicBoxes');
+    $mocked_submit->mock(
+        'submit',
         sub {
-            return 'Verified';
+            my $args = $_[1];
+            if ( $args->{method} eq 'domains__details' ) {
+                return { raaVerificationStatus => 'Verified' };
+            }
+            $mocked_submit->original('submit')->(@_);
         }
     );
-    my $domain = create_domain();
     throws_ok {
         $logic_boxes->resend_verification_email( id => $domain->id );
-    } qr/Domain already verified/;
+    }
+    qr/Domain already verified/;
+    $mocked_submit->unmock('submit');
 };
 
 subtest 'Resend Email Verification For Domain Requiring Verification - Successful' => sub {
     my $domain = create_domain();
 
+    my $response;
     lives_ok {
-        $logic_boxes->resend_verification_email( id => $domain->id );
+        $response = $logic_boxes->resend_verification_email( id => $domain->id );
     };
+    ok( $response->{result} eq 'true', 'Responded with True' );
 };
 
 done_testing;

--- a/t/role/command/domain/10-resend_verification_email.t
+++ b/t/role/command/domain/10-resend_verification_email.t
@@ -12,8 +12,6 @@ use lib "$FindBin::Bin/../../../lib";
 use Test::WWW::LogicBoxes::Domain qw( create_domain );
 use Test::WWW::LogicBoxes qw( create_api );
 
-use WWW::LogicBoxes;
-
 my $logic_boxes = create_api;
 
 subtest 'Resend Email Verification For Domain That Does Not Exist - Throws Exception' => sub {
@@ -50,7 +48,7 @@ subtest 'Resend Email Verification For Domain Requiring Verification - Successfu
     lives_ok {
         $response = $logic_boxes->resend_verification_email( id => $domain->id );
     };
-    ok( $response->{result} eq 'true', 'Responded with True' );
+    ok( $response == 1, 'Responded with True' );
 };
 
 done_testing;

--- a/t/role/command/domain/10-resend_verification_email.t
+++ b/t/role/command/domain/10-resend_verification_email.t
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use Test::MockModule;
+
+use FindBin;
+use lib "$FindBin::Bin/../../../lib";
+use Test::WWW::LogicBoxes::Domain qw( create_domain );
+use Test::WWW::LogicBoxes qw( create_api );
+
+use WWW::LogicBoxes::Domain;
+
+my $logic_boxes = create_api;
+
+subtest 'Resend Email Verification For Domain That Does Not Exist - Throws Exception' => sub {
+    throws_ok {
+        $logic_boxes->resend_verification_email( id => 999999999 );
+    } qr/No such domain exists/;
+};
+
+subtest 'Resend Email Verification For Domain That Does Not Need It - Throws Exception' => sub {
+    my $mocked_domain_status = Test::MockModule->new('WWW::LogicBoxes::Domain');
+    $mocked_domain_status->mock(
+        'verification_status',
+        sub {
+            return 'Verified';
+        }
+    );
+    my $domain = create_domain();
+    throws_ok {
+        $logic_boxes->resend_verification_email( id => $domain->id );
+    } qr/Domain already verified/;
+};
+
+subtest 'Resend Email Verification For Domain Requiring Verification - Successful' => sub {
+    my $domain = create_domain();
+
+    lives_ok {
+        $logic_boxes->resend_verification_email( id => $domain->id );
+    };
+};
+
+done_testing;


### PR DESCRIPTION
In WWW::LogicBoxes
  Added pod link for the new function

In WWW::LogicBoxes::Role::Command::Domain
  Created resend_verification_email sub to resend the raa verification
  email
  Added pod documentation for the new sub

In WWW::LogicBoxes::Role::Command::Raw
  Added raa/resend-verificaion to the routes

In t/role/command/domain/10-resend_verification_email.t
  Created following subtests:
  Resend Email Verification For Domain That
  Does Not Exist - Throws Exception
  Resend Email Verification For Domain That Does Not Need It - Throws
  Exception
  Resend Email Verification For Domain Requiring Verification -
  Successful