### PR TITLE
Accept all actiontypes

### DIFF
--- a/lib/WWW/LogicBoxes/Domain/Factory.pm
+++ b/lib/WWW/LogicBoxes/Domain/Factory.pm
@@ -20,14 +20,34 @@ sub construct_from_response {
     }
 
     if( $response->{actiontype} ) {
+
+        # actiontype is an undocumented return value.  I spoke with a LogicBoxes
+        # engineer who told me that it identifies an action that has been
+        # requested but not yet completed - their API is asynchronous and a
+        # successful call simply means an action has been queued for processing.
+        #
+        # Furthermore, the range of values for actiontype is not well defined -
+        # new values are added routinely as needed. Accordingly, we need to be
+        # lenient in looking at this value.
+        #
+        # In general, the only actiontype we need to concern ourselves with is
+        # AddtransferDomain, which means the domain is in the process of being
+        # transfered to LogicBoxes.  That gets a different class constructed for
+        # it. All other values should be treated normally.
+        #
+        # Known values include:
+        # AddtransferDomain - domain is being transferred in
+        # DelDomain - a domain is being deleted
+        # ModContact - a contact is being updated
+        # ParkDomain - a domain has expired and is being parked at the
+        #       registrar for the redemption period.
+        # RenewDomain - a domain is being renewed
+
         if( $response->{actiontype} eq 'AddTransferDomain' ) {
             return WWW::LogicBoxes::DomainTransfer->construct_from_response( $response );
         }
-        elsif( $response->{actiontype} eq 'DelDomain' || $response->{actiontype} eq 'ModContact' ) {
-            return WWW::LogicBoxes::Domain->construct_from_response( $response );
-        }
         else {
-            croak $response->{actiontype} . ' is an unknown action type';
+            return WWW::LogicBoxes::Domain->construct_from_response( $response );
         }
     }
     else {


### PR DESCRIPTION
When querying an order, LogicBoxes can return the undocumented
field "actiontype", which indicates that a previously requested action
on the order is still being processed.  The code has always recognized
a few of these actiontypes, and contructs a different class if the
actiontype indicates that a domain is still being transferred in.
However, the code throws an error on any actiontype it does not
recognize.  Unfortunately, LogicBoxes says that new actiontypes can
be added at any time.  Furthermore, there are no known actiontypes that
should prevent normal object construction.

In partituclar, the actiontypes RenewDomain and ParkDomain have been
observed when trying to reload an order immediately after requesting
renewal or deletion of a domain, and the code croaking on these has
caused errors to be reported even when no actual error has occurred.

This patch makes the code accept all actiontype values so as to avoid
croaking when it is not necessary.