### PR TITLE
API route to submit the Domain Secret

### DIFF
--- a/lib/WWW/LogicBoxes/Role/Command/Domain/Transfer.pm
+++ b/lib/WWW/LogicBoxes/Role/Command/Domain/Transfer.pm
@@ -6,7 +6,7 @@ use warnings;
 use Moose::Role;
 use MooseX::Params::Validate;
 
-use WWW::LogicBoxes::Types qw( DomainName DomainTransfer Int );
+use WWW::LogicBoxes::Types qw( DomainName DomainTransfer Int Str );
 
 use WWW::LogicBoxes::DomainRequest::Transfer;
 
@@ -127,6 +127,37 @@ sub resend_transfer_approval_mail_by_id {
     };
 }
 
+sub submit_auth_code {
+    my $self = shift;
+    my ( %args ) = validated_hash(
+        \@_,
+        id        => { isa => Int },
+        auth_code => { isa => Str }, # aka EPP key
+    );
+
+    return try {
+        my $response = $self->submit({
+            method => 'domains__transfer__submit_auth_code',
+            params => {
+                'order-id'  => $args{id},
+                'auth-code' => $args{auth_code},
+            }
+        });
+
+        if ( lc $response->{result} eq 'success' ) {
+            return;
+        }
+
+        croak $response;
+    }
+    catch {
+        if ( $_ =~ m/You are not allowed to perform this action/ ) {
+            croak 'No matching order found';
+        }
+        croak $_;
+    };
+}
+
 1;
 
 __END__
@@ -235,5 +266,18 @@ Given an Integer representing an in progress L<transfer|WWW::LogicBoxes::DomainT
     $logic_boxes->resend_transfer_approval_mail_by_id( $domain_transfer->id );
 
 Given an Integer representing an in progress L<transfer|WWW::LogicBoxes::DomainTransfer> that has not yet been approved by the L<admin contact|WWW::LogicBoxes::Contact> as specified by the losing registrar, will resend the transfer approval email.  If this method is used on a completed transfer, a registration, or a domain that has already been approved this method will croak with an error.
+
+=head2 submit_auth_code
+
+    use WWW::LogicBoxes;
+    use WWW::LogicBoxes::DomainTransfer;
+
+    my $logic_boxes = WWW::LogicBoxes->new( ... );
+    my $epp_value = somehow_get_code_from_current_registrar( ... );
+
+    my $domain_transfer = $logic_boxes->get_domain_by_id( ... );
+    $logic_boxes->submit_auth_code( { id => $domain_transfer->id, auth_code => $epp_value } );
+
+Submits the Domain Secret (also known as Authorization Code, also known as EPP key) for an in-progress domain transfer. Successfull submission results in silent return, otherwise, croaks.
 
 =cut

--- a/lib/WWW/LogicBoxes/Role/Command/Raw.pm
+++ b/lib/WWW/LogicBoxes/Role/Command/Raw.pm
@@ -28,7 +28,7 @@ Readonly our $API_METHODS => {
             qw(available suggest-names v5/suggest-names validate-transfer search customer-default-ns orderid details details-by-name locks tel/cth-details)
         ],
         POST => [
-            qw(register transfer eu/transfer eu/trade uk/transfer renew modify-ns add-cns modify-cns-name modify-cns-ip delete-cns-ip modify-contact modify-privacy-protection modify-auth-code enable-theft-protection disable-theft-protection tel/modify-whois-pref resend-rfa uk/release cancel-transfer delete restore de/recheck-ns dotxxx/assoication-details raa/resend-verification)
+            qw(register transfer eu/transfer eu/trade uk/transfer renew modify-ns add-cns modify-cns-name modify-cns-ip delete-cns-ip modify-contact modify-privacy-protection modify-auth-code enable-theft-protection disable-theft-protection tel/modify-whois-pref resend-rfa uk/release cancel-transfer delete restore de/recheck-ns dotxxx/assoication-details raa/resend-verification transfer/submit-auth-code)
         ],
     },
     contacts => {

--- a/t/role/command/domain/transfer/00-object.t
+++ b/t/role/command/domain/transfer/00-object.t
@@ -11,7 +11,7 @@ use WWW::LogicBoxes::Role::Command::Domain::Transfer;
 use Readonly;
 Readonly my $ROLE => 'WWW::LogicBoxes::Role::Command::Domain::Transfer';
 
-subtest "$ROLE is a well formed roll" => sub {
+subtest "$ROLE is a well formed role" => sub {
     is_role_ok( $ROLE );
     requires_method_ok( $ROLE, 'submit' );
 };
@@ -21,6 +21,7 @@ subtest "$ROLE has the correct methods" => sub {
     has_method_ok( $ROLE, 'transfer_domain' );
     has_method_ok( $ROLE, 'delete_domain_transfer_by_id' );
     has_method_ok( $ROLE, 'resend_transfer_approval_mail_by_id' );
+    has_method_ok( $ROLE, 'submit_auth_code' );
 };
 
 done_testing;

--- a/t/role/command/domain/transfer/05-submit_auth_code.t
+++ b/t/role/command/domain/transfer/05-submit_auth_code.t
@@ -1,0 +1,65 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use Test::MockModule;
+
+use FindBin;
+use lib "$FindBin::Bin/../../../../lib";
+use Test::WWW::LogicBoxes qw( create_api );
+
+use Carp;
+
+my $logic_boxes = create_api();
+
+subtest 'Submit Auth Code to Transfer That Does Not Exist' => sub {
+    throws_ok {
+        $logic_boxes->submit_auth_code(
+            {
+                id        => 999999999,
+                auth_code => '9FP4HL79BMH9FVU5B',
+            }
+        );
+    } qr/No matching order found/, 'Proper error on non-existing domain transfer';
+};
+
+subtest 'Arbitrary Error on Auth Code Submission' => sub {
+    my $mocked_logic_boxes = Test::MockModule->new( 'WWW::LogicBoxes' );
+    my $error_msg = 'Note: this is an arbitrary error message!';
+
+    $mocked_logic_boxes->mock( 'submit', sub {
+        croak $error_msg;
+    });
+
+    throws_ok {
+        $logic_boxes->submit_auth_code(
+            {
+                id        => 999999999,
+                auth_code => '9FP4HL79BMH9FVU5B',
+            }
+        );
+    } qr/$error_msg/, 'Arbitrary error message passed as-is';
+};
+
+subtest 'Sucessfull Auth Code Submission' => sub {
+    my $mocked_logic_boxes = Test::MockModule->new( 'WWW::LogicBoxes' );
+    $mocked_logic_boxes->mock( 'submit', sub {
+        return {
+            result => 'Success'
+        };
+    });
+
+    lives_ok {
+        $logic_boxes->submit_auth_code(
+            {
+                id        => 999999999,
+                auth_code => '9FP4HL79BMH9FVU5B',
+            },
+        );
+    } 'Lives through auth code submission';
+};
+
+done_testing;


### PR DESCRIPTION
API route to submit the Domain Secret (aka Authorization Code, aka EPP key) for an in-progress domain transfer.
As of 08/10/21, the original API route documentation: https://freeaccount.myorderbox.com/kb/node/2446